### PR TITLE
Remove default catalog

### DIFF
--- a/src/main/scala/com/hindog/spark/jdbc/catalog/CatalogMetadata.scala
+++ b/src/main/scala/com/hindog/spark/jdbc/catalog/CatalogMetadata.scala
@@ -7,19 +7,26 @@ import org.apache.spark.sql.types.{StringType, StructField, StructType}
 import java.sql.{Connection, ResultSet}
 
 class CatalogMetadata(conn: Connection) extends AbstractMetadata(conn) {
-  override def fetch() = {
+  override def fetch(): List[Row] = {
     if (isDebugEnabled) {
       log.info("Fetching Catalog Metadata")
     }
     withStatement { stmt =>
-      val rs = stmt.executeQuery(s"select '${CatalogMetadata.catalogName}' as catalogName")
-      extractResult(rs)(getRow)
+      val catalogName = CatalogMetadata.catalogName
+      if (catalogName.nonEmpty) {
+        val rs = stmt.executeQuery(s"SELECT '$catalogName' as catalogName")
+        extractResult(rs)(getRow)
+      } else {
+        List.empty[Row]
+      }
     }
   }
-  override def schema: StructType = StructType(Seq(StructField("TABLE_CAT", StringType, false)))
+
+  override def schema: StructType = StructType(Seq(StructField("TABLE_CAT", StringType, nullable = false)))
+
   override def getRow(rs: ResultSet): Row = new GenericRowWithSchema(Array[Any](rs.getString("catalogName")), schema)
 }
 
 object CatalogMetadata {
-  def catalogName: String = sys.props.getOrElse("com.hindog.spark.jdbc.catalog.name", "Spark")
+  def catalogName: String = sys.props.getOrElse("com.hindog.spark.jdbc.catalog.name", "")
 }


### PR DESCRIPTION
Remove default catalog, for Hive tables, the existence of the catalog level will cause conflicts between SQL completion and SQL execution in BI tools.